### PR TITLE
Fix exception handling in XmlRpc connector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "supervisorphp/configuration": "^0.2",
         "php-http/message": "^1.5",
         "php-http/guzzle5-adapter": "^0.5",
-        "guzzlehttp/psr7": "^1.4"
+        "guzzlehttp/psr7": "^1.4",
+        "behat/behat": "^3.0"
     },
     "suggest": {
         "lstrojny/fxmlrpc": "A modern, super fast XML/RPC client for PHP >=5.4",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "lstrojny/fxmlrpc": "0.9.3",
+        "lstrojny/fxmlrpc": "^0.12",
         "guzzlehttp/guzzle": "^4.0",
         "zendframework/zend-xmlrpc": ">=2.3.3",
         "phpspec/phpspec": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,15 @@
     },
     "require-dev": {
         "lstrojny/fxmlrpc": "^0.12",
-        "guzzlehttp/guzzle": "^4.0",
+        "guzzlehttp/guzzle": "^5.0",
         "zendframework/zend-xmlrpc": ">=2.3.3",
         "phpspec/phpspec": "^2.4",
         "henrikbjorn/phpspec-code-coverage" : "^1.0",
-        "behat/behat": "^3.0",
         "ramsey/array_column": "^1.1",
-        "supervisorphp/configuration": "^0.2"
+        "supervisorphp/configuration": "^0.2",
+        "php-http/message": "^1.5",
+        "php-http/guzzle5-adapter": "^0.5",
+        "guzzlehttp/psr7": "^1.4"
     },
     "suggest": {
         "lstrojny/fxmlrpc": "A modern, super fast XML/RPC client for PHP >=5.4",

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -13,7 +13,6 @@ use Supervisor\Configuration\Section;
 use Supervisor\Connector\XmlRpc;
 use Supervisor\Supervisor;
 use fXmlRpc\Client;
-use fXmlRpc\Transport\Guzzle4Bridge;
 use GuzzleHttp\Client as GuzzleClient;
 
 /**
@@ -50,9 +49,14 @@ class FeatureContext implements Context, SnippetAcceptingContext
 
     protected function setUpConnector()
     {
+        $guzzleClient = new GuzzleClient(['defaults' => ['auth' => ['user', '123']]]);
+
         $client = new Client(
             'http://127.0.0.1:9001/RPC2',
-            new Guzzle4Bridge(new GuzzleClient(['defaults' => ['auth' => ['user', '123']]]))
+            new \fXmlRpc\Transport\HttpAdapterTransport(
+                new \Http\Message\MessageFactory\GuzzleMessageFactory(),
+                new \Http\Adapter\Guzzle5\Client($guzzleClient)
+            )
         );
 
         $connector = new XmlRpc($client);

--- a/spec/Connector/XmlRpcSpec.php
+++ b/spec/Connector/XmlRpcSpec.php
@@ -3,7 +3,7 @@
 namespace spec\Supervisor\Connector;
 
 use fXmlRpc\ClientInterface;
-use fXmlRpc\Exception\ResponseException;
+use fXmlRpc\Exception\FaultException;
 use PhpSpec\ObjectBehavior;
 
 class XmlRpcSpec extends ObjectBehavior
@@ -32,7 +32,7 @@ class XmlRpcSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_the_call_fails(ClientInterface $client)
     {
-        $e = ResponseException::fault([
+        $e = FaultException::fault([
             'faultString' => 'Invalid response',
             'faultCode'   => 100,
         ]);
@@ -44,7 +44,7 @@ class XmlRpcSpec extends ObjectBehavior
 
     function it_throws_a_known_exception_when_proper_fault_returned(ClientInterface $client)
     {
-        $e = ResponseException::fault([
+        $e = FaultException::fault([
             'faultString' => 'UNKNOWN_METHOD',
             'faultCode'   => 1,
         ]);

--- a/src/Connector/XmlRpc.php
+++ b/src/Connector/XmlRpc.php
@@ -2,10 +2,10 @@
 
 namespace Supervisor\Connector;
 
+use fXmlRpc\Exception\FaultException;
 use Supervisor\Connector;
 use Supervisor\Exception\Fault;
 use fXmlRpc\ClientInterface;
-use fXmlRpc\Exception\ResponseException;
 
 /**
  * Basic XML-RPC Connector using fXmlRpc.
@@ -34,7 +34,7 @@ class XmlRpc implements Connector
     {
         try {
             return $this->client->call($namespace.'.'.$method, $arguments);
-        } catch (ResponseException $e) {
+        } catch (FaultException $e) {
             throw Fault::create($e->getFaultString(), $e->getFaultCode());
         }
     }


### PR DESCRIPTION
The exception classes in the xmlrpc dependency have changed. This pull request fixes them.

I've gone for v0.12 of the dependency as that is the last version that supports PHP 5.4 (which is what your minimum requirement has been set to). This PR however also works with the latest version (v0.12).